### PR TITLE
phat_js: Add eval_async_js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "phat_js"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "hex_fmt",
  "ink",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "phat_js"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "hex_fmt",
  "ink",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,11 +158,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chumsky"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3172a80699de358070dd99f80ea8badc6cdf8ac2417cb5a96e6d81bf5fe06d"
+checksum = "b9c28d4e5dd9a9262a38b231153591da6ce1471b818233f4727985d3dd0ed93c"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -168,16 +175,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "concat-idents"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d"
-dependencies = [
- "quote",
- "syn 2.0.39",
 ]
 
 [[package]]
@@ -351,18 +348,13 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -427,7 +419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -702,12 +694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,11 +791,12 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "phat_js"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
+ "hex_fmt",
  "ink",
  "parity-scale-codec",
- "pink-extension 0.5.0",
+ "pink-extension 0.5.1",
  "scale-info",
 ]
 
@@ -831,16 +818,19 @@ dependencies = [
 
 [[package]]
 name = "pink-extension"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe261c26b4018364320cf86615b6c82c068b3aa00ada4de3147842f97a20c548"
+checksum = "0f00d09691bd1922017d47eeb9a6d4bcd5aa35b163a00dc1e730ce8859ab1f05"
 dependencies = [
+ "hex",
  "ink",
  "log",
  "num_enum",
  "parity-scale-codec",
  "pink-extension-macro",
+ "pink-types",
  "scale-info",
+ "serde",
  "this-crate",
 ]
 
@@ -857,6 +847,16 @@ dependencies = [
  "quote",
  "syn 2.0.39",
  "unzip3",
+]
+
+[[package]]
+name = "pink-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cbfce16d3b505cfe560e1278836e16f400274d04395773ceb7879029b409429"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
 ]
 
 [[package]]
@@ -941,7 +941,6 @@ dependencies = [
  "chumsky",
  "hex",
  "hex_fmt",
- "md5",
  "parity-scale-codec",
  "qjsbind",
  "qjsc",
@@ -957,12 +956,6 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "cc",
- "concat-idents",
- "cstr",
- "hex",
- "scopeguard",
- "serde",
- "tinyvec",
 ]
 
 [[package]]
@@ -977,8 +970,6 @@ dependencies = [
  "qjs-extensions",
  "qjsbind",
  "scale-info",
- "serde",
- "serde_json",
  "this-crate",
 ]
 
@@ -1420,9 +1411,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ overflow-checks = false
 ink = { version = "4.3", default-features = false, features = ["static-buffer-1M256K"] }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
-serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = { version = "1", default-features = false, features = ["alloc"] }
 qjsbind = { path = "qjs-sys/qjsbind", default-features = false }
 qjs-extensions = { path = "qjs-sys/qjs-extensions", default-features = false, features = ["base64", "hex", "scale2"] }
 pink = { package = "pink-extension", version = "0.4.4-dev.2", default-features = false, features = ["dlmalloc"] }
@@ -34,8 +32,6 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
-    "serde/std",
-    "serde_json/std",
     "pink/std",
     "qjsbind/std",
     "qjs-extensions/std",

--- a/phat_js/Cargo.toml
+++ b/phat_js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phat_js"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 description = "Provide a function to call the JSDelegate in a phat contract cluster"
 license = "MIT"

--- a/phat_js/Cargo.toml
+++ b/phat_js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phat_js"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "Provide a function to call the JSDelegate in a phat contract cluster"
 license = "MIT"

--- a/phat_js/Cargo.toml
+++ b/phat_js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phat_js"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 description = "Provide a function to call the JSDelegate in a phat contract cluster"
 license = "MIT"
@@ -16,7 +16,8 @@ ink = { version = "4.3", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-pink = { package = "pink-extension", version = "0.5", default-features = false }
+pink = { package = "pink-extension", version = "0.5.1", default-features = false }
+hex_fmt = "0.3"
 
 [features]
 default = ["std"]

--- a/phat_js/lib.rs
+++ b/phat_js/lib.rs
@@ -354,7 +354,7 @@ pub fn eval_async_js(code: JsCode, args: Vec<String>) -> JsValue {
 
 fn polyfill_script(seed: impl AsRef<[u8]>) -> String {
     let seed = hex_fmt::HexFmt(seed);
-    format!(
+    alloc::format!(
         r#"
         (function(g) {{
             const seed = "{seed}";

--- a/phat_js/lib.rs
+++ b/phat_js/lib.rs
@@ -340,7 +340,7 @@ pub fn eval_all_with(
 /// let res = phat_js::eval_async_js(js_code, Vec::new());
 /// assert_eq!(res, JsValue::String("42".into()));
 /// ```
-pub fn eval_async_js(code: JsCode, args: Vec<String>) -> JsValue {
+pub fn eval_async_code(code: JsCode, args: Vec<String>) -> JsValue {
     let code_bytes = match &code {
         JsCode::Source(source) => source.as_bytes(),
         JsCode::Bytecode(bytecode) => bytecode.as_slice(),
@@ -350,6 +350,13 @@ pub fn eval_async_js(code: JsCode, args: Vec<String>) -> JsValue {
     let polyfill = polyfill_script(pink::vrf(&code_hash));
     let codes = alloc::vec![JsCode::Source(polyfill), code];
     pink::ext().js_eval(codes, args)
+}
+
+/// Evaluate async JavaScript with SideVM QuickJS.
+///
+/// Same as [`eval_async_code`], but takes a string as the JavaScript code.
+pub fn eval_async_js(src: &str, args: &[String]) -> JsValue {
+    eval_async_code(JsCode::Source(src.into()), args.to_vec())
 }
 
 fn polyfill_script(seed: impl AsRef<[u8]>) -> String {


### PR DESCRIPTION
The new `eval_async_js` use sidevm-quickjs as backend.