### PR TITLE
Run Zama tfhe in quickJS

### DIFF
--- a/WapoJS/Makefile
+++ b/WapoJS/Makefile
@@ -16,7 +16,7 @@ endif
 BUILD_OUTPUT=$(addsuffix .wasm, $(TARGETS))
 OPTIMIZED_OUTPUT=$(addsuffix -stripped.wasm, $(TARGETS))
 OPT?=0
-COMMON_FEATURES=mem-stats,js-hash,js-crypto,js-wasm,js-websocket,js-crypto,env-browser
+COMMON_FEATURES=mem-stats,js-hash,js-crypto,js-wasm,js-websocket,js-crypto,env-nodejs
 
 
 .PHONY: all clean opt deep-clean install run test wasi rs

--- a/WapoJS/Makefile
+++ b/WapoJS/Makefile
@@ -16,7 +16,7 @@ endif
 BUILD_OUTPUT=$(addsuffix .wasm, $(TARGETS))
 OPTIMIZED_OUTPUT=$(addsuffix -stripped.wasm, $(TARGETS))
 OPT?=0
-COMMON_FEATURES=mem-stats,js-hash,js-crypto,js-wasm,js-websocket,js-crypto,env-nodejs
+COMMON_FEATURES=mem-stats,js-hash,js-crypto,js-wasm,js-websocket,js-crypto,env-browser
 
 
 .PHONY: all clean opt deep-clean install run test wasi rs

--- a/WapoJS/examples/zama-tfhe/package.json
+++ b/WapoJS/examples/zama-tfhe/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "wapo-zama-tfhe-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "webpack",
+    "build:debug": "webpack --mode=development",
+    "test": "webpack && wapo-quickjs dist/index.js"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "node-tfhe": "^0.6.2"
+  },
+  "devDependencies": {
+    "@swc/cli": "^0.1.62",
+    "@swc/core": "^1.3.51",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "eslint": "^8.0.1",
+    "eslint-config-standard-with-typescript": "^26.0.0",
+    "eslint-plugin-import": "^2.25.2",
+    "eslint-plugin-n": "^15.0.0",
+    "eslint-plugin-promise": "^6.0.0",
+    "path-browserify": "^1.0.1",
+    "ts-loader": "^9.4.2",
+    "typescript": "*",
+    "util": "^0.12.5",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1"
+  }
+}

--- a/WapoJS/examples/zama-tfhe/spack.config.js
+++ b/WapoJS/examples/zama-tfhe/spack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    entry: {
+        web: __dirname + "/src/index.ts",
+    },
+    output: {
+        path: __dirname + "/dist",
+    },
+};

--- a/WapoJS/examples/zama-tfhe/src/index.ts
+++ b/WapoJS/examples/zama-tfhe/src/index.ts
@@ -1,0 +1,45 @@
+import {
+    CompactFheUint8List,
+    TfheCompactPublicKey,
+    TfheConfigBuilder,
+    TfheClientKey,
+    ShortintParameters,
+    ShortintParametersName,
+} from "node-tfhe";
+
+function createTfheKeypair() {
+    const block_params = new ShortintParameters(
+      ShortintParametersName.PARAM_MESSAGE_2_CARRY_2_COMPACT_PK_PBS_KS,
+    );
+    const config = TfheConfigBuilder.default()
+      .use_custom_parameters(block_params)
+      .build();
+    const clientKey = TfheClientKey.generate(config);
+    let publicKey = TfheCompactPublicKey.new(clientKey);
+    publicKey = TfheCompactPublicKey.deserialize(publicKey.serialize());
+    return { clientKey, publicKey };
+};
+
+function encryptUint8(value: number, pubkey: TfheCompactPublicKey): Uint8Array {
+    const uint8Array = new Uint8Array([value]);
+    const encrypted = CompactFheUint8List.encrypt_with_compact_public_key(
+      uint8Array,
+      pubkey,
+    );
+    return encrypted.serialize();
+};
+
+function main() {
+    const { clientKey, publicKey } = createTfheKeypair();
+    const value = 100;
+    const encrypted = encryptUint8(value, publicKey);
+    console.log(`Encrypted: ${encrypted}`);
+    const compactList = CompactFheUint8List.deserialize(encrypted);
+    let encryptedList = compactList.expand();
+    encryptedList.forEach((v) => {
+      const decrypted = v.decrypt(clientKey);
+      console.log(`Decrypted: ${decrypted}`);
+    });
+}
+
+main();

--- a/WapoJS/examples/zama-tfhe/src/index.ts
+++ b/WapoJS/examples/zama-tfhe/src/index.ts
@@ -1,3 +1,4 @@
+import "./patchWasm"
 import {
     CompactFheUint8List,
     TfheCompactPublicKey,
@@ -42,4 +43,8 @@ function main() {
     });
 }
 
-main();
+try {
+  main()
+} finally {
+  process.exit(0)
+}

--- a/WapoJS/examples/zama-tfhe/src/patchWasm.js
+++ b/WapoJS/examples/zama-tfhe/src/patchWasm.js
@@ -1,0 +1,11 @@
+const fs = require("fs");
+
+function decodeAsset(asset) {
+    // asset format:
+    // data:application/wasm;base64,AGFzbQEAAAABnARDYA...
+    return Buffer.from(asset.slice(asset.indexOf(",") + 1), "base64");
+    // Or faster:
+    // return Wapo.base64Decode(asset.slice(asset.indexOf(",") + 1), true);
+}
+
+fs.writeFileSync("/tfhe_bg.wasm", decodeAsset(require("node-tfhe/tfhe_bg.wasm")));

--- a/WapoJS/examples/zama-tfhe/tsconfig.json
+++ b/WapoJS/examples/zama-tfhe/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+      "outDir": "./dist/",
+      "noImplicitAny": true,
+      "module": "es6",
+      "target": "es2020",
+      "allowJs": true,
+      "moduleResolution": "node"
+    }
+  }
+  

--- a/WapoJS/examples/zama-tfhe/webpack.config.js
+++ b/WapoJS/examples/zama-tfhe/webpack.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index',
+  mode: 'production',
+  output: {
+    filename: 'index.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+    fallback: {
+      "util": require.resolve("util/"),
+      "path": require.resolve("path-browserify"),
+      "fs": false
+    }
+  },
+  target: 'web',
+  devtool: 'source-map',
+};

--- a/WapoJS/examples/zama-tfhe/webpack.config.js
+++ b/WapoJS/examples/zama-tfhe/webpack.config.js
@@ -24,6 +24,6 @@ module.exports = {
       "fs": false
     }
   },
-  target: 'web',
+  target: 'node',
   devtool: 'source-map',
 };

--- a/WapoJS/examples/zama-tfhe/webpack.config.js
+++ b/WapoJS/examples/zama-tfhe/webpack.config.js
@@ -14,6 +14,10 @@ module.exports = {
         use: 'ts-loader',
         exclude: /node_modules/,
       },
+      {
+          test: /\.wasm$/,
+          type: "asset/inline",
+      },
     ],
   },
   resolve: {


### PR DESCRIPTION
This PR demostrate an example of running [Zama tfhe](https://github.com/zama-ai/tfhe-rs) in Phat QuickJS engine. It's the PoC of move FHE key generation and plaintext encryption into SGX, since Phat QuickJS engine here will be embeded in Wapo Worker, and eventually run in SGX env.